### PR TITLE
backport to Linux 5.4

### DIFF
--- a/RME-Babyace-Pro-ALSA-Mixer.patch
+++ b/RME-Babyace-Pro-ALSA-Mixer.patch
@@ -434,9 +434,9 @@ index a5f65a9a0254..aad2683ff793 100644
  int snd_usb_mixer_apply_create_quirk(struct usb_mixer_interface *mixer)
  {
  	int err = 0;
-@@ -2286,6 +2701,9 @@ int snd_usb_mixer_apply_create_quirk(struct usb_mixer_interface *mixer)
- 	case USB_ID(0x0194f, 0x010c): /* Presonus Studio 1810c */
- 		err = snd_sc1810_init_mixer(mixer);
+@@ -2281,6 +2281,9 @@ int snd_usb_mixer_apply_create_quirk(struct usb_mixer_interface *mixer)
+	case USB_ID(0x2a39, 0x3fd4): /* RME */
+ 		err = snd_rme_controls_create(mixer);
  		break;
 +	case USB_ID(0x2a39, 0x3fb0): /* RME Babyface Pro FS */
 +		err = snd_bbfpro_controls_create(mixer);


### PR DESCRIPTION
5.4 is the latest stable version of the realtime patchset, so I backported this ALSA mixer patch for Linux 5.4. I'm not asking you to actually merge this, but I want this reference to be here in the upstream repository in case anyone else wants to use this. If you want to close this, go ahead.